### PR TITLE
Fix ignore() method code example issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ public function rules()
     
     return [
         'id' => [new ExistsEloquent(Post::class)],
-        'username' => [new UniqueEloquent(User::class, 'username')->ignore($postId)],
+        'username' => [(new UniqueEloquent(User::class, 'username'))->ignore($postId)],
         'title' => ['string'],
         'content' => ['string'],
         'comments.*.id' => [


### PR DESCRIPTION
This example didn't work for me - only adding in these parenthesis allowed it to work.